### PR TITLE
Don't isolate namespace, let the helper work without extra calls to install

### DIFF
--- a/lib/cloudflare_image_resizing/engine.rb
+++ b/lib/cloudflare_image_resizing/engine.rb
@@ -1,12 +1,5 @@
 module CloudflareImageResizing
   class Engine < ::Rails::Engine
-    isolate_namespace CloudflareImageResizing
-    engine_name "cloudflare_image_resizing"
-
     config.cloudflare_image_resizing = Configuration.new
-
-    config.to_prepare do
-      ::ApplicationController.helper(CloudflareImageResizing::Helper)
-    end
   end
 end


### PR DESCRIPTION
Let the helper work without extra calls to install